### PR TITLE
Fix Editor Problems

### DIFF
--- a/Attributes/Editor/ReadOnlyPropertyDrawer.cs
+++ b/Attributes/Editor/ReadOnlyPropertyDrawer.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 using System;
 using UnityEditor;
 using UnityEngine;
@@ -43,3 +44,4 @@ namespace SombraStudios.Shared.Attributes.Editor
         }
     }
 }
+#endif

--- a/Attributes/Editor/TagPropertyDrawer.cs
+++ b/Attributes/Editor/TagPropertyDrawer.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
@@ -75,3 +76,4 @@ namespace SombraStudios.Shared.Attributes.Editor
         }
     }
 }
+#endif

--- a/Audio/Strategies/AudioStrategyExample.asset
+++ b/Audio/Strategies/AudioStrategyExample.asset
@@ -12,11 +12,12 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 36ab8a429f39cdb4c90dd48abc738bab, type: 3}
   m_Name: AudioStrategyExample
   m_EditorClassIdentifier: 
+  <Id>k__BackingField: fcc785d6-5477-4735-a71f-16d825fd8c87
   _showLogs: 0
   _clips: []
   _volume:
-    MinValue: 0.5
+    MinValue: 0
     MaxValue: 1
   _pitch:
-    MinValue: 0.5
-    MaxValue: 1
+    MinValue: -3
+    MaxValue: 3

--- a/Optimization/FrameRate/FrameRateStrategyExample.asset
+++ b/Optimization/FrameRate/FrameRateStrategyExample.asset
@@ -12,5 +12,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 1715ad01f9a044e44b29c35aaeb9b873, type: 3}
   m_Name: FrameRateStrategyExample
   m_EditorClassIdentifier: 
+  <Id>k__BackingField: 5882152c-d8fb-410d-b51b-ef0a2e7ba5b8
+  _showLogs: 0
   TargetFrameRate: 60
-  ShowLogs: 1

--- a/Scenes/SceneChangeTool.cs
+++ b/Scenes/SceneChangeTool.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -143,3 +144,4 @@ namespace SombraStudios.Shared.Scenes
         }
     }
 }
+#endif

--- a/Systems/Teleport/Teleporter.cs
+++ b/Systems/Teleport/Teleporter.cs
@@ -2,7 +2,6 @@ using System.Collections;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 using UnityEngine.Events;
-using UnityEditor;
 
 namespace SombraStudios.Shared.Systems.Teleport
 {
@@ -12,7 +11,7 @@ namespace SombraStudios.Shared.Systems.Teleport
     public class Teleporter : MonoBehaviour
     {
         //[SerializeField] private Object DestinationScene;
-        [SerializeField] private SceneAsset DestinationScene;
+        [SerializeField] private string DestinationScene;
         [SerializeField] private string DestinationSpawnPointName;
 
         [Header("Events")]
@@ -31,13 +30,13 @@ namespace SombraStudios.Shared.Systems.Teleport
 
             OnTeleporting();
 
-            if (SceneManager.GetActiveScene().name == DestinationScene.name)
+            if (SceneManager.GetActiveScene().name == DestinationScene)
             {
                 TeleportToDestination(teleportable);
             }
             else
             {
-                StartCoroutine(TeleportToNewScene(DestinationScene.name, teleportable));
+                StartCoroutine(TeleportToNewScene(DestinationScene, teleportable));
             }
         }
 
@@ -45,7 +44,7 @@ namespace SombraStudios.Shared.Systems.Teleport
         private IEnumerator TeleportToNewScene(string sceneName, ITeleportable teleportable)
         {
             Scene currentScene = SceneManager.GetActiveScene();
-            AsyncOperation newSceneAsyncLoad = SceneManager.LoadSceneAsync(DestinationScene.name, LoadSceneMode.Additive);
+            AsyncOperation newSceneAsyncLoad = SceneManager.LoadSceneAsync(DestinationScene, LoadSceneMode.Additive);
 
             while (!newSceneAsyncLoad.isDone)
             {

--- a/Utility/PrefabInstantiateOnLoad/PrefabInstantiateOnLoadEditor.cs
+++ b/Utility/PrefabInstantiateOnLoad/PrefabInstantiateOnLoadEditor.cs
@@ -1,3 +1,4 @@
+#if UNITY_EDITOR
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;
@@ -108,3 +109,4 @@ namespace SombraStudios.Shared.Utility.PrefabInstantiateOnLoad
         }
     }
 }
+#endif


### PR DESCRIPTION
- Added some preprocessor for UnityEditor library because they did't allow to make a build
- In Teleporter.cs changed SceneAsset to string because the SceneAsset is a component for only Editor
- The problem with the .assets was the Id, idk why it makes other changes but are examples so I don't think that changes are a problem